### PR TITLE
Fix initial search bar position on home page

### DIFF
--- a/search.js
+++ b/search.js
@@ -65,7 +65,12 @@
   // Determine if we are on the Home page (root index.html)
   function isHomePage() {
     const path = window.location.pathname || '';
-    return /(?:^|\/)index\.html$/.test(path) || path === '/' || path === '';
+    // Treat explicit index.html as home
+    if (/(?:^|\/)index\.html$/i.test(path)) return true;
+    // If there's no file extension and the path ends with a slash, it's a directory index (home when served from a subpath)
+    if (!/\.[a-zA-Z0-9]+$/.test(path) && path.endsWith('/')) return true;
+    // Fallbacks for very short/empty paths
+    return path === '/' || path === '';
   }
 
   // Add a class to <html> for page-context-specific styling


### PR DESCRIPTION
Update `isHomePage()` to correctly identify the home page on initial load, including subpath roots.

This ensures the search bar is always centered on the home page, preventing it from appearing in the top-right and overlapping content on initial load, especially when the site is served from a subpath (e.g., `/something/`).

---
<a href="https://cursor.com/background-agent?bcId=bc-33c2eec9-49fe-4746-9cd3-47c496006c02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33c2eec9-49fe-4746-9cd3-47c496006c02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

